### PR TITLE
fix: paths in test files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,7 @@
   "extends": [
     "next",
     "next/core-web-vitals",
-    "prettier",
-    "plugin:import/typescript"
+    "prettier"
   ],
   "rules": {
     "prettier/prettier": "error",

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,12 @@ const customJestConfig = {
   transform: {
     '^.+\\.mjs$': 'babel-jest',
   },
-  moduleDirectories: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '@/components/(.*)': '<rootDir>/src/components/$1',
+    '@/content/(.*)': '<rootDir>/content/$1',
+    '@/contexts/(.*)': '<rootDir>/src/contexts/$1',
+    '@/mocks/(.*)': '<rootDir>/src/__mocks__/$1',
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { render, RenderResult } from '@testing-library/react';
 import { ChakraProvider } from '@chakra-ui/provider';
 import Home from '../pages/index';
 import { ContentProvider } from '@/contexts/content/ContentProvider';
-import { mockContentContext } from '../__mocks__/mockContexts/mockContexts';
+import { mockContentContext } from '@/mocks/mockContexts/mockContexts';
 
 describe('Home page', () => {
   const renderHomePage = (): RenderResult =>

--- a/src/components/organisms/Footer/Footer.test.tsx
+++ b/src/components/organisms/Footer/Footer.test.tsx
@@ -1,9 +1,9 @@
 import { act, render, RenderResult, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ChakraProvider } from '@chakra-ui/provider';
 import { Footer } from './Footer';
 import { ContentProvider } from '@/contexts/content/ContentProvider';
-import { ChakraProvider } from '@chakra-ui/provider';
-import { mockContentContext } from '../../../__mocks__/mockContexts/mockContexts';
+import { mockContentContext } from '@/mocks/mockContexts/mockContexts';
 
 jest.mock('next/link', () => {
   return ({ children }: { children: JSX.Element }) => {
@@ -21,7 +21,7 @@ describe('Footer component', () => {
       </ChakraProvider>,
     );
 
-  it('directs user to the About Us page', async () => {
+  it('should direct user to the About Us page', async () => {
     const aboutUsText = mockContentContext.navigation[0].label;
     const { getByText, queryByText } = renderFooter();
 
@@ -34,7 +34,7 @@ describe('Footer component', () => {
     });
   });
 
-  it('directs user to the Contact Us page', async () => {
+  it('should direct user to the Contact Us page', async () => {
     const { getByText, queryByText } = renderFooter();
 
     const contactUsLink = mockContentContext.navigation[1].label;
@@ -48,7 +48,7 @@ describe('Footer component', () => {
     });
   });
 
-  it('directs user to the Donate page', async () => {
+  it('should direct user to the Donate page', async () => {
     const { getByText, queryByText } = renderFooter();
 
     const donateLink = mockContentContext.navigation[2].label;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@/components/*": ["src/components/*"],
       "@/content/*": ["content/*"],
       "@/contexts/*": ["src/contexts/*"],
-      "@/styles/*": ["src/styles/*"]
+      "@/styles/*": ["src/styles/*"],
+      "@/mocks/*": ["src/__mocks__/*"]
     }
   },
   "include": [


### PR DESCRIPTION
- Remove plugin import for TypeScript for ESLint
- fix(tests): Use `moduleNameMaper` property for absolute imports
- chore: add absolute paths for mocks
- Use absolute path for mocks and update test texts
